### PR TITLE
return '--- {}' from bin/release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# bin/release <build-dir>
 
-cat <<EOF
----
-EOF
+echo "--- {}"


### PR DESCRIPTION
I had to make this minor adjustment to make Heroku launch a multi-buildpack app at all.

(I'm gonna propose a more far-reaching change in a separate pull request)

Cheers,
Martin
