### PR TITLE
always use release config from last given buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+set -e
+
+function indent() {
+  c='s/^/       /'
+  case $(uname) in
+    Darwin) sed -l "$c";;
+    *)      sed -u "$c";;
+  esac
+}
+
 for BUILDPACK in $(cat $1/.buildpacks); do
   dir=$(mktemp -t buildpackXXXXX)
   rm -rf $dir
@@ -30,6 +40,11 @@ for BUILDPACK in $(cat $1/.buildpacks); do
       if [ $? != 0 ]; then
         exit 1
       fi
+
+      $dir/bin/release $1 > $1/last_pack_release.out
     fi
   fi
 done
+
+echo "Using release configuration from last framework $framework:" | indent
+cat $1/last_pack_release.out | indent

--- a/bin/release
+++ b/bin/release
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# bin/release <build-dir>
 
-cat <<EOF
----
-EOF
+cat $1/last_pack_release.out


### PR DESCRIPTION
I had trouble running a Ruby/Rack app alongside a console-based app of a different platform as multi-buildpack swallows the bin/release output of the individual buildpacks.

Thus, I propose always using the release config of the last buildpack given in `.buildpacks`.

Feel free to pull if you like this approach. If you don't I would suggest to pull the minimal fix in https://github.com/ddollar/heroku-buildpack-multi/pull/1 instead.

Cheers,
Martin
