### PR TITLE
Config merging; build environment variables

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,6 +5,14 @@ set -e
 BUILD_DIR=$1
 CACHE_DIR=$2
 
+SUPPORT_DIR=$(dirname $0)/../support/
+
+RELEASE_CONFIG=$BUILD_DIR/release_config.yml
+BUILD_ENV=$CACHE_DIR/build_env
+
+mkdir -p $BUILD_DIR
+mkdir -p $CACHE_DIR
+
 function indent() {
   c='s/^/       /'
   case $(uname) in
@@ -12,6 +20,21 @@ function indent() {
     *)      sed -u "$c";;
   esac
 }
+
+function with_env() {
+  if [ -s $BUILD_ENV ]; then
+    env "$(cat $BUILD_ENV)" $*
+  else
+    env $*
+  fi
+}
+
+# reset build environment
+echo "=====> Resetting build environment"
+> $BUILD_ENV
+
+echo "=====> Generating empty release configuration"
+echo "--- {}" > $RELEASE_CONFIG
 
 unset GIT_DIR
 
@@ -37,20 +60,22 @@ for BUILDPACK in $(cat $BUILD_DIR/.buildpacks); do
 
     chmod +x $dir/bin/{detect,compile,release}
 
-    framework=$($dir/bin/detect $BUILD_DIR)
+    framework=$(with_env $dir/bin/detect $BUILD_DIR)
 
     if [ $? == 0 ]; then
       echo "=====> Detected Framework: $framework"
-      $dir/bin/compile $BUILD_DIR $CACHE_DIR
+      with_env $dir/bin/compile $BUILD_DIR $CACHE_DIR
 
       if [ $? != 0 ]; then
         exit 1
       fi
 
-      $dir/bin/release $BUILD_DIR > $BUILD_DIR/last_pack_release.out
+      config=$(with_env $dir/bin/release $BUILD_DIR)
+
+      $SUPPORT_DIR/update_config $RELEASE_CONFIG $BUILD_ENV <<< "${config}"
     fi
   fi
 done
 
-echo "Using release configuration from last framework $framework:" | indent
-cat $BUILD_DIR/last_pack_release.out | indent
+echo "Using release configuration from framework $framework:" | indent
+cat $RELEASE_CONFIG | indent

--- a/bin/release
+++ b/bin/release
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-cat $1/last_pack_release.out
+cat $1/release_config.yml

--- a/support/update_config
+++ b/support/update_config
@@ -1,0 +1,71 @@
+#!/usr/bin/env ruby
+# support/update_config config.yml build_env < new_config_data
+
+require "yaml"
+require "shellwords"
+
+release_config_file = ARGV[0]
+build_env_file = ARGV[1]
+
+class ReleaseConfig
+  def initialize(config = {})
+    @config = config
+  end
+
+  def [](key)
+    @config[key]
+  end
+
+  def []=(key, value)
+    @config[key] = value
+  end
+
+  def addons
+    self["addons"] ||= []
+  end
+
+  def build_env
+    self["build_env"] ||= {}
+  end
+
+  def config_vars
+    self["config_vars"] ||= {}
+  end
+
+  def default_process_types
+    self["default_process_types"] ||= {}
+  end
+
+  def merge(other)
+    merged = ReleaseConfig.new
+
+    merged["addons"] = addons | other.addons
+    merged["build_env"] = build_env.merge(other.build_env)
+    merged["config_vars"] = config_vars.merge(other.config_vars)
+    merged["default_process_types"] = default_process_types.merge(other.default_process_types)
+
+    merged
+  end
+
+  def write_release_config(filename)
+    File.open(filename, "w") do |file|
+      YAML.dump @config, file
+    end
+  end
+
+  def write_build_env(filename)
+    File.open(filename, "w") do |file|
+      build_env.each do |key, value|
+        file.puts "#{key}=#{value}"
+      end
+    end
+  end
+end
+
+source = ReleaseConfig.new(YAML.load_file(release_config_file))
+new = ReleaseConfig.new(YAML.load($stdin.read))
+
+merged = source.merge(new)
+
+merged.write_release_config release_config_file
+merged.write_build_env build_env_file


### PR DESCRIPTION
This commit includes two separate but related features:
1. Instead of only taking the last release config, the YAML is parsed and merged after each step. It's quite dumb now, just a "deep merge" on the values emitted by each step, but could be upgraded to even, say, merge "PATH" settings, etc.
2. It adds awareness for a custom key in bin/release's yaml: `build_env`. It's like `config_vars`, except that each stage in a multi-build is run with the combined `build_env` of each previous step.

I'd like some feedback on this, but here's my use case:

I needed libcairo (with development dependencies), which isn't available on heroku. So I put together a buildpack for it, but realized there was no way to pass information from my buildpack into the ruby build pack for installing the "cairo" gem.

So now my cairo buildpack now does this in bin/release:

```
#!/bin/sh
# bin/release <build-dir>

set -e

BUILD_DIR=$1

LIB_PATH="$BUILD_DIR/vendor/cairo/lib:$BUILD_DIR/vendor/pixman-0.26/lib"
INCLUDE_PATH="$BUILD_DIR/vendor/cairo/include/cairo:$BUILD_DIR/vendor/pixman-0.26/include/pixman-1"
PKG_CONFIG_PATH="$BUILD_DIR/vendor/cairo/lib/pkgconfig:$BUILD_DIR/vendor/pixman-0.26/lib/pkgconfig"

cat << EOF

---
build_env:
  BUNDLE_BUILD__CAIRO: "--with-opt-lib=${LIB_PATH} --with-opt-include=${INCLUDE_PATH} --with-pkg-config=${PKG_CONFIG_PATH}"
config_vars:
  PATH: "bin:/app/vendor/cairo/bin:/usr/local/bin:/usr/bin:/bin"
EOF
```

So that a user can do a multi-build pack with cairo + ruby, do 'gem "cairo"', and everything just works!
