### PR TITLE
Allow buildpack to export environment for subsequent packs

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -46,7 +46,7 @@ for BUILDPACK in $(cat $1/.buildpacks); do
 
       $dir/bin/release $1 > $1/last_pack_release.out
       if [ -f $dir/bin/after_compile ]; then
-        source $dir/bin/after_compile
+        source $dir/bin/after_compile $1
       fi
       echo "running next buildpack with environment:"
       env


### PR DESCRIPTION
This enables a buildpack to become entirely composable. Great work by @salsify

For example. Am currently using this to enable deploying a node.js app that depends on cairo.

Note, as some of the existing heroku buildpacks completely override previously set ENV variables at compile time, tweaks may be needed in other buildpacks themselves.

https://github.com/heroku/heroku-buildpack-nodejs/pull/30
