### PR TITLE
bin/compile bails if bin/detect exits with code 1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -41,7 +41,7 @@ for BUILDPACK in $(cat $1/.buildpacks); do
 
     if [ $exit_code == 0 ]; then
       echo "=====> Detected Framework: $framework"
-      $dir/bin/compile $1 $2
+      $dir/bin/compile $1 $2 $3
 
       if [ $? != 0 ]; then
         exit 1


### PR DESCRIPTION
And then the whole slug creation (and git push to heroku) fails.

This pull request fixes it.
