### PR TITLE
Merge buildpack build environments

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -52,8 +52,8 @@ for BUILDPACK in $(cat $1/.buildpacks); do
       fi
 
       # check if the buildpack left behind an environment for subsequent ones
-      if [ -e $1/build_env.sh ]; then
-        source $1/build_env.sh
+      if [ -e $dir/export ]; then
+        source $dir/export
       fi
 
       if [ -x $dir/bin/release ]; then


### PR DESCRIPTION
This is very similar to #11, although it merges responsibility from `after_compile` into `compile` to avoid having to hardcode paths.

I don't like the idea of dropping `build_env.sh` in the app's root directory (which is also where `last_pack_release.out` lands), but I'm not sure what a better location for communication would be...

Like @davidjrice, I have a buildpack that's just responsible for vendoring dependencies.  My `vendor` function looks like:

``` bash
function vendor() {
  binary="$1"
  path="$2"

  echo "Fetching $binary" | indent
  mkdir -p $path
  curl $binary -s -o - | tar xz -C $path -f -

  [ -d "$path/bin" ] && export PATH=$path/bin:$PATH
  export CPPPATH="$path/include:$CPPPATH"
  export CPATH="$path/include:$CPATH"
  export LIBRARY_PATH="$path/lib:$LIBRARY_PATH"
  export LD_LIBRARY_PATH="$path/lib:$LD_LIBRARY_PATH"
  [ -d "$path/lib/pkgconfig" ] && export PKG_CONFIG_PATH="$path/lib/pkgconfig:$PKG_CONFIG_PATH"

  true
}
```

...and is used like so:

``` bash
vendor "https://s3.amazonaws.com/<bucket>/protobuf-2.5.0-1.tar.gz" "$1/vendor/protobuf"
```

This way `vendor` builds up the environment and creates a file in `.profile.d` (re-pointing to `/app`) via:

``` bash
cat <<EOF > $BUILD_DIR/.profile.d/deps.sh
# build and runtime paths
export PATH="${PATH//$BUILD_DIR//app}:\$PATH"
export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:${LD_LIBRARY_PATH//$BUILD_DIR//app}"
export LIBRARY_PATH="\$LIBRARY_PATH:${LIBRARY_PATH//$BUILD_DIR//app}"
export PKG_CONFIG_PATH="\$PKG_CONFIG_PATH:${PKG_CONFIG_PATH//$BUILD_DIR//app}"
export CPPPATH="\$CPPPATH:${CPPPATH//$BUILD_DIR//app}"
export CPATH="\$CPATH:${CPATH//$BUILD_DIR//app}"
EOF
```

It writes out `$BUILD_DIR/build_env.sh` via:

``` bash
cat <<EOF > $BUILD_DIR/build_env.sh
export PATH="$PATH:\$PATH"
export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH\":$LD_LIBRARY_PATH"
export LIBRARY_PATH="\$LIBRARY_PATH\":$LIBRARY_PATH"
export PKG_CONFIG_PATH="\$PKG_CONFIG_PATH\":$PKG_CONFIG_PATH"
export CPPPATH="\$CPPPATH\":$CPPPATH"
export CPATH="\$CPATH\":$CPATH"
EOF
```

...which is then picked up by the multipack's `compile`.
