### PR TITLE
Fix #24: improve error messages during compilation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -66,6 +66,7 @@ for BUILDPACK in $(cat $1/.buildpacks); do
     else
       echo "framework not detected; error messages may display below" | indent
       echo "$framework"
+      exit 1
     fi
   fi
 done


### PR DESCRIPTION
My goal with the added `echo` statements is to make it easier for people with custom buildpacks to debug the `detect` script. Hopefully that also solves issue #24.
