### PR TITLE
Add compatibility with gitsubmodules

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -31,10 +31,10 @@ for BUILDPACK in $(cat $1/.buildpacks); do
       curl -s "$url" | tar xvz -C "$dir" >/dev/null 2>&1
     else
       git clone $url $dir >/dev/null 2>&1
-      git submodule update --init >/dev/null 2>&1
     fi
     cd $dir
-
+    git submodule update --init >/dev/null 2>&1
+    
     if [ "$branch" != "" ]; then
       git checkout $branch >/dev/null 2>&1
     fi


### PR DESCRIPTION
When it clone a buildpack repo some of them have git sub module inside so i fix this issue, can be useful for other people
