### PR TITLE
Support git submodules

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -31,6 +31,10 @@ for BUILDPACK in $(cat $1/.buildpacks); do
       curl -s "$url" | tar xvz -C "$dir" >/dev/null 2>&1
     else
       git clone $url $dir >/dev/null 2>&1
+      if [ -f "$dir/.gitmodules" ]; then
+        echo "=====> Detected git submodules. Initializing..."
+        $(cd $dir && git submodule update --init --recursive)
+      fi
     fi
     cd $dir
 


### PR DESCRIPTION
In order to support git-cloned buildpacks that contain submodules, we have to do a submodule update --init --recursive. Specifically, I had to make this change in order to support the ruby buildpack.