### PR TITLE
Fix syntax error when updating submodules

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ for BUILDPACK in $(cat $1/.buildpacks); do
       git clone $url $dir >/dev/null 2>&1
       if [ -f "$dir/.gitmodules" ]; then
         echo "=====> Detected git submodules. Initializing..."
-        $(cd $dir && git submodule update --init --recursive)
+        (cd $dir && git submodule update --init --recursive)
       fi
     fi
     cd $dir


### PR DESCRIPTION
Accidentally was evaluating the output of the submodule update command as a bash command.

Sorry about that! That's what I get for just eye-balling it on my home machine last night. 
Tested this one and it works.