### PR TITLE
Remove specifications on buildpack urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Use multiple buildpacks on your app
     $ heroku config:add BUILDPACK_URL=https://github.com/ddollar/heroku-buildpack-multi.git
 
     $ cat .buildpacks
-    https://github.com/heroku/heroku-buildpack-nodejs.git#0198c71daa8
-    https://github.com/heroku/heroku-buildpack-ruby.git#v86
+    https://github.com/heroku/heroku-buildpack-nodejs.git
+    https://github.com/heroku/heroku-buildpack-ruby.git
 
 ## License
 


### PR DESCRIPTION
@ddollar Thanks very much for this buildpack.

I used it as directed in the README today and and I consistently got the following:
```
-----> Fetching custom git buildpack... done
-----> Multipack app detected
=====> Downloading Buildpack: https://github.com/heroku/heroku-buildpack-nodejs.git

 !     Push rejected, failed to compile Multipack app
```

Once I removed the specified tag/sha in `.buildpacks` all was well.
