### PR TITLE
Updated heroku command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Use multiple buildpacks on your app
 
 ## Usage
 
-    $ heroku config:add BUILDPACK_URL=https://github.com/ddollar/heroku-buildpack-multi.git
+    $ heroku buildpacks:set https://github.com/ddollar/heroku-buildpack-multi.git
 
     $ cat .buildpacks
     https://github.com/heroku/heroku-buildpack-nodejs.git#0198c71daa8


### PR DESCRIPTION
The Heroku command for setting a buildpack URL has been changed to:

`heroku buildpacks:set BUILDPACK_URL`