### PR TITLE
Remove all buildpack directories after `compile` to reduce disk usage

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -12,9 +12,16 @@ function indent() {
 
 unset GIT_DIR
 
+declare -a dirs
+cleanup() {
+  rm -fr "${dirs[@]}"
+}
+trap cleanup EXIT
+
 for BUILDPACK in $(cat $1/.buildpacks); do
   dir=$(mktemp -t buildpackXXXXX)
   rm -rf $dir
+  dirs[${#dirs[*]}]="${dir}"
 
   url=${BUILDPACK%#*}
   branch=${BUILDPACK#*#}


### PR DESCRIPTION
Clean up temporary directory after the `compile`.

Actually this won't help nothing for Heroku, but on pseudo Heroku environment, this would help to prevent disk-full by buildpack temporary files.