### PR TITLE
Add support for comments (starting with #)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ Use multiple buildpacks on your app
     https://github.com/heroku/heroku-buildpack-nodejs.git#0198c71daa8
     https://github.com/heroku/heroku-buildpack-ruby.git#v86
 
+## Comments
+
+You can use # at the beginning of lines to leave a comment. For example
+
+    $ cat .buildpacks
+    # Buildpacks File
+
+    # Node Buildpack set at specific commit to avoid regression issue in issue 42
+    https://github.com/heroku/heroku-buildpack-nodejs.git#0198c71daa8
+
+    # Ruby Buildpack for scheduled jobs
+    https://github.com/heroku/heroku-buildpack-ruby.git#v86
+
 ## License
 
 MIT

--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,7 @@ function indent() {
 
 unset GIT_DIR
 
-for BUILDPACK in $(cat $1/.buildpacks); do
+for BUILDPACK in $(cat $1/.buildpacks | grep -v '^#'); do
   dir=$(mktemp -t buildpackXXXXX)
   rm -rf $dir
 


### PR DESCRIPTION
This allows you to leave notes in the .buildpacks file. To use, you enter the 

This can be useful for more context on why specific build packs are used, why specific branches/commits/tags are used, and an overall cleaner **.buildpacks** 