### PR TITLE
Add pointer to Heroku's native multi-buildpacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Deprecated
 
-This project is deprecated and is no longer being maintained.
+Because Heroku now has [native support for multiple buildpacks](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app), this project is deprecated and is no longer being maintained.
 
 Please check out my current project [Convox](https://convox.com) for all of your deployment needs!


### PR DESCRIPTION
It's alarming to discover a deprecation warning with no migration path. This points people over to what they should use now.