### PR TITLE
Add doc pointer to CloudFoundry-focussed fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,8 @@ Please fork it to your own account and update your `BUILDPACK_URL`
 
 You can also check out Heroku's [built-in buildpack-multi support](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app).
 
+Cloud Foundry users, amongst others, may wish to use a community-maintained and
+actively developed version of this buildpack, available at
+https://bitbucket.org/cf-utilities/cf-buildpack-multi/
+
 Please check out my current project [Convox](https://convox.com) for all of your deployment needs!


### PR DESCRIPTION
This PR adds a documentation pointer to an actively maintained, CloudFoundry-focussed fork of this buildpack.
