### PR TITLE
Remove deprecation warning & auto-quit

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,15 +5,6 @@ set -e
 YELLOW='\033[1;33m'
 RESET='\033[0m'
 
-echo -e "${YELLOW}WARNING: This buildpack is no longer maintained."
-echo -e
-echo -e "Please choose a different buildpack or go to https://github.com/ddollar/heroku-buildpack-multi"
-echo "and fork it to your own account."
-echo -e
-echo -e "This buildpack will cease to function at the stroke of midnight on January 1, 2017.${RESET}"
-
-[ $(date +%Y%m%d%H%M%S) -gt "20170101000000" ] && exit 1
-
 function indent() {
   c='s/^/       /'
   case $(uname) in


### PR DESCRIPTION
This buildpack expired on `2017-01-01` as it was no longer maintained. The deprecation warning says to either clone the repo, or switch to the new Heroku buildpack options. For the time being, staying on the old buildpack is keeping us from deploying. Hence, forking the repo, and removing the `exit` command.